### PR TITLE
Tested functions, BugFixes, Key line tint around Dyn Island

### DIFF
--- a/filcnaplo/ios/livecard/livecard.swift
+++ b/filcnaplo/ios/livecard/livecard.swift
@@ -11,6 +11,33 @@ struct Widgets: WidgetBundle {
   }
 }
 
+// Color Converter
+extension Color {
+    init(hex: String, alpha: Double = 1.0) {
+        var hexValue = hex.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+
+        if hexValue.hasPrefix("#") {
+            hexValue.remove(at: hexValue.startIndex)
+        }
+
+        var rgbValue: UInt64 = 0
+        Scanner(string: hexValue).scanHexInt64(&rgbValue)
+
+        let red = Double((rgbValue & 0xFF0000) >> 16) / 255.0
+        let green = Double((rgbValue & 0x00FF00) >> 8) / 255.0
+        let blue = Double(rgbValue & 0x0000FF) / 255.0
+
+        self.init(
+            .sRGB,
+            red: red,
+            green: green,
+            blue: blue,
+            opacity: alpha
+        )
+    }
+}
+
+
 // We need to redefined live activities pipe
 struct LiveActivitiesAppAttributes: ActivityAttributes, Identifiable {
   public struct ContentState: Codable, Hashable { }
@@ -69,7 +96,9 @@ struct LockScreenLiveActivityView: View {
           .padding(.trailing, CGFloat(24))
     }
     .activityBackgroundTint(
-        lesson!.color != "0xFF676767" ? Color(lesson!.color) : nil
+        lesson!.color == "#676767"
+        ? nil
+        : Color(hex: lesson!.color)
     )
   }
 }
@@ -147,7 +176,11 @@ struct LiveCardWidget: Widget {
             .font(.system(size: CGFloat(10)))
         }
       }
-      .keylineTint(.accentColor)
+      .keylineTint(
+        lesson!.color == "#676767"
+        ? nil
+        : Color(hex: lesson!.color)
+      )
     }
   }
 }

--- a/filcnaplo/lib/api/providers/live_card_provider.dart
+++ b/filcnaplo/lib/api/providers/live_card_provider.dart
@@ -87,6 +87,7 @@ class LiveCardProvider extends ChangeNotifier {
 
   // Debugging
   static DateTime _now() {
+    // return DateTime(2023, 8, 31, 8, 0);
     return DateTime.now();
   }
 
@@ -110,7 +111,8 @@ class LiveCardProvider extends ChangeNotifier {
     switch (currentState) {
       case LiveCardState.duringLesson:
         return {
-          "color": _settings.liveActivityColor.toString(),
+          "color":
+              '#${_settings.liveActivityColor.toString().substring(10, 16)}',
           "icon": currentLesson != null
               ? SubjectIcon.resolveName(subject: currentLesson?.subject)
               : "book",
@@ -143,7 +145,8 @@ class LiveCardProvider extends ChangeNotifier {
         final diff = getFloorDifference();
 
         return {
-          "color": _settings.liveActivityColor.toString(),
+          "color":
+              '#${_settings.liveActivityColor.toString().substring(10, 16)}',
           "icon": iconFloorMap[diff] ?? "cup.and.saucer",
           "title": "Szünet",
           "description": "go $diff".i18n.fill([


### PR DESCRIPTION
### Tests were successful ✅

<img width="328" alt="Screenshot 2023-08-29 at 13 28 59" src="https://github.com/refilc/naplo/assets/47987707/6c4adafb-74c1-4350-b064-b2858416a7c0">
<img width="332" alt="Screenshot 2023-08-29 at 13 29 15" src="https://github.com/refilc/naplo/assets/47987707/3ed8418a-5ff6-46e5-a024-afec19253258">

<br>


### Added key line tint around dynamic island➕

<img width="191" alt="Screenshot 2023-08-29 at 13 29 31" src="https://github.com/refilc/naplo/assets/47987707/84319803-26a5-403d-9b5c-7c374eea2ea3">
