### PR TITLE
gradestreak probléma javítás: nem ignorálja a szöveges értékelést

### DIFF
--- a/refilc_kreta_api/lib/providers/grade_provider.dart
+++ b/refilc_kreta_api/lib/providers/grade_provider.dart
@@ -153,6 +153,8 @@ class GradeProvider with ChangeNotifier {
     for (Grade grade in grs) {
       if (grade.value.value == 5) {
         gradeStreak++;
+      } else if (grade.value.value == 0){
+        
       } else {
         break;
       }

--- a/refilc_kreta_api/lib/providers/grade_provider.dart
+++ b/refilc_kreta_api/lib/providers/grade_provider.dart
@@ -153,9 +153,7 @@ class GradeProvider with ChangeNotifier {
     for (Grade grade in grs) {
       if (grade.value.value == 5) {
         gradeStreak++;
-      } else if (grade.value.value == 0){
-        
-      } else {
+      } else if (grade.value.value !=0) {
         break;
       }
     }


### PR DESCRIPTION
https://discord.com/channels/1111649116020285532/1307009925230100581
![image](https://github.com/user-attachments/assets/1624935a-f6b0-4369-8a0c-92e9f20610e5)
![image](https://github.com/user-attachments/assets/412a2aee-bd35-4536-8cea-5cb343126362)
self-hosted webszerverrel teszteltem a jegyeket, azzal ment.