### PR TITLE
sync hiba javítás? - v5.0.6

### DIFF
--- a/refilc/lib/api/providers/sync.dart
+++ b/refilc/lib/api/providers/sync.dart
@@ -84,20 +84,20 @@ Future<void> syncAll(BuildContext context) async {
         return;
       }
 
-      if (user.user!.accessTokenExpire.isBefore(DateTime.now())) {
-        String authRes = await Provider.of<KretaClient>(context, listen: false)
-                .refreshLogin() ??
-            '';
-        if (authRes != 'success') {
-          if (kDebugMode) print('ERROR: failed to refresh login');
-          lock = false;
-          return Future.value();
-        } else {
-          if (kDebugMode) print('INFO: access token refreshed');
-        }
-      } else {
-        if (kDebugMode) print('INFO: access token is not expired');
-      }
+      // if (user.user!.accessTokenExpire.isBefore(DateTime.now())) {
+      //   String authRes = await Provider.of<KretaClient>(context, listen: false)
+      //           .refreshLogin() ??
+      //       '';
+      //   if (authRes != 'success') {
+      //     if (kDebugMode) print('ERROR: failed to refresh login');
+      //     lock = false;
+      //     return Future.value();
+      //   } else {
+      //     if (kDebugMode) print('INFO: access token refreshed');
+      //   }
+      // } else {
+      //   if (kDebugMode) print('INFO: access token is not expired');
+      // }
     }()),
 
     syncStatus(Provider.of<GradeProvider>(context, listen: false).fetch()),

--- a/refilc_kreta_api/lib/client/client.dart
+++ b/refilc_kreta_api/lib/client/client.dart
@@ -276,7 +276,11 @@ class KretaClient {
 
     print("REFRESH TOKEN BELOW");
     print(refreshToken);
-
+    print(loginUser.accessTokenExpire);
+    print(DateTime.now().toIso8601String());
+    if(!DateTime.now().isAfter(loginUser.accessTokenExpire)) {
+        return 'success';
+    }
     if (refreshToken != null) {
       // print("REFRESHING LOGIN");
       Map? res = await postAPI(KretaAPI.login,

--- a/refilc_kreta_api/lib/client/client.dart
+++ b/refilc_kreta_api/lib/client/client.dart
@@ -91,7 +91,7 @@ class KretaClient {
           headerMap.remove("authorization");
           print("DEBUG: 401 error, refreshing login");
           print("DEBUG: 401 error, URL: $url");
-          // await refreshLogin();
+          await refreshLogin();
         } else {
           break;
         }
@@ -160,7 +160,7 @@ class KretaClient {
 
         res = await client.post(Uri.parse(url), headers: headerMap, body: body);
         if (res.statusCode == 401) {
-          // await refreshLogin();
+          await refreshLogin();
           headerMap.remove("authorization");
         } else {
           break;
@@ -234,7 +234,7 @@ class KretaClient {
 
         if (res.statusCode == 401) {
           headerMap.remove("authorization");
-          // await refreshLogin();
+          await refreshLogin();
         } else {
           break;
         }


### PR DESCRIPTION
Elmélet az, h az érvényes tokent ne refreshelje. Már volt 1x elmentve az accessToken-nak a lejárati ideje, így a kód ellenőrzi h az alapján lejárt-e, ha idő szerint még nem akkor nem refresheli a tokent, így ha egyszerre többször probbál refresh tokenezni (pld 401-es kódnál) nem hal bele talán.

Gyakorlatban `3 napja` tesztelem, minden betöltött rendesen, múltkor 2-1 nap után meghalt az app. 
Még nem vagyok benne biztos, hogy működik, de mivel jön a téli szünet és nem igazán nézem ez alatt, ezért nyitom most  a pull requestet.
Értesítésekről: idáig se működött nálam tökéletesen, szóval arról sokat nem tudok mondani, de most néha-néha kaptam néhány dologról értesítést.